### PR TITLE
amidine can be next to any C

### DIFF
--- a/open_combind/features/ifp.py
+++ b/open_combind/features/ifp.py
@@ -144,7 +144,7 @@ class Molecule:
         #            ('[CX3](=[NH2X3+])[NH2X3]', 1, [1, 2])]
         # These are pulled from pharmit's positive and negative ions
         pos_smartss = [('[+,+2,+3,+4]', 0, [0]), #positive ions first
-                    ('[$(CC)](=N)N', 2, [1,2]),
+                    ('[$(C*)](=N)N', 2, [1,2]),
                     ('C(N)(N)=N', 0, [1,2,3]),
                     ('[$([nH]1cncc1)]', 0, [0])]
         neg_smartss =[('[-,-2,-3,-4]', 0, [0]),


### PR DESCRIPTION
## Description
Change amidine SMARTS string from only recognizing motif next to aliphatic ethane group.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Find more salt bridges
 
## Status
- [ ] Ready to go