### PR TITLE
Fixes Memory/Runtime issues with MCSS calculations

### DIFF
--- a/open_combind/features/mcss.py
+++ b/open_combind/features/mcss.py
@@ -205,9 +205,8 @@ def compute_mcss(st1, st2, params):
         mcss, num_atoms, mcss_mol = get_info_from_results(res)
         pose1 = subMol(st1,st1.GetSubstructMatch(mcss_mol))
         pose2 = subMol(st2,st2.GetSubstructMatch(mcss_mol))
-        pose1 = AssignBondOrdersFromTemplate(pose2, pose1)
         assert pose1.HasSubstructMatch(pose2) or pose2.HasSubstructMatch(pose1)
-    except (AssertionError, ValueError):
+    except AssertionError:
         # some pesky problem ligands (see SKY vs LEW on rcsb) get around default ringComparison
         # but this is slow, so only should do it when we need to do it (but checking is also slow)
 
@@ -228,7 +227,7 @@ def setup_MCS_params():
     params = rdFMCS.MCSParameters()
     params.AtomCompareParameters.RingMatchesRingOnly = True
     params.AtomCompareParameters.CompleteRingsOnly = True
-    params.BondTyper = rdFMCS.BondCompare.CompareAny
+    params.BondTyper = rdFMCS.BondCompare.CompareOrderExact
     params.AtomTyper = CompareHalogens()
 
     return params
@@ -240,12 +239,7 @@ def calculate_rmsd(pose1, pose2, eval_rmsd=False):
     pose1, pose2: rdkit.Mol
     eval_rmsd: verify that RMSD calculation is the same as obrms
     """
-    try:
-        pose1 = AssignBondOrdersFromTemplate(pose2, pose1)
-        assert pose1.HasSubstructMatch(pose2) or pose2.HasSubstructMatch(pose1)
-    except (AssertionError, Chem.KekulizeException, ValueError):
-        pose2 = AssignBondOrdersFromTemplate(pose1, pose2)
-        assert pose1.HasSubstructMatch(pose2) or pose2.HasSubstructMatch(pose1), f"{pose1.GetProp('_Name')}&{pose2.GetProp('_Name')}"
+    assert pose1.HasSubstructMatch(pose2) or pose2.HasSubstructMatch(pose1), f"{pose1.GetProp('_Name')}&{pose2.GetProp('_Name')}"
     try:
         rmsd = Chem.CalcRMS(pose1,pose2)
     except:

--- a/open_combind/features/mcss.py
+++ b/open_combind/features/mcss.py
@@ -101,7 +101,7 @@ def mcss_mp(sts1, sts2, processes=1):
             continue
         unfinished += [(g1[1],g2[1])]
 
-    results = mp(compute_mcss_and_rmsd,unfinished,processes)
+    results = mp(compute_mcss_and_rmsd,unfinished,processes, maxtasksperchild=3)
     rmsds_bottom = sum(results)
     full_simi_mat = rmsds_bottom + rmsds_bottom.T - np.diag(np.diag(rmsds_bottom))
     return np.where(full_simi_mat<0,np.inf,full_simi_mat)

--- a/open_combind/stats_data/benchmarking.py
+++ b/open_combind/stats_data/benchmarking.py
@@ -35,33 +35,36 @@ def query_to_helpers(query_ligand, prot_name, helper_list_root, selection_criter
 
     return helper_for_query['helper'].tolist()
 
-def run_featurization(root, helper_ligands, query_fname, protein_name, helper_list_root, native_loc='.', selection_criterion="affinity",processes=1):
+def run_featurization(root, helper_ligands, query_fname, protein_name, helper_list_root, native_loc='.', selection_criterion="affinity",processes=1,template='structures/template/*.template',check_center_ligs=False, skip_featurization=False, extra_helper_ligands=[]):
     query_ligand = query_fname.split('/')[-1].split('-')[0].split('_')[0]
     helpers_to_use = query_to_helpers(query_ligand, protein_name, helper_list_root, selection_criterion)
     helper_ligands = [ligand for ligand in helper_ligands if ligand.split('/')[-1].split('-')[0] in helpers_to_use] + [query_fname]
+    helper_ligands += extra_helper_ligands
     print(helper_ligands)
+    template_file = sorted(glob(template))[0]
     native_poses = {}
     for native_path in native_loc:
         name = native_path.split('/')[-1].replace('.sdf', '')
         # sts = Chem.SDMolSupplier(native_path)
         native_poses[name] = native_path
     print(native_poses)
-    return featurize(root, helper_ligands, native_poses, ifp_version, mcss_version, shape_version, False, False, processes, 100, False)
+    return featurize(root, helper_ligands, native_poses, ifp_version, mcss_version, shape_version, False, False, processes, 100, False,template_file=template_file,check_center_ligs=check_center_ligs,skip_featurization=skip_featurization)
 
 
 def featurize(root, poseviewers, native_loc, ifp_version, mcss_custom,
-              shape_version, no_mcss, use_shape, processes, max_poses, no_cnn):
+              shape_version, no_mcss, use_shape, processes, max_poses, no_cnn,template_file='structures/template/*.template',check_center_ligs=False,skip_featurization=False):
     from open_combind.features.features import Features
     if use_shape:
         print("Shape is not currently implemented outside of Schrodinger\n Shape has not been evaluated for performance in pose-prediction")
 
     features = Features(root, ifp_version=ifp_version, shape_version=shape_version,
-                        max_poses=max_poses, cnn_scores=not no_cnn)
+                        max_poses=max_poses, cnn_scores=not no_cnn,template=template_file,check_center_ligs=check_center_ligs)
+    if not skip_featurization:
 
-    features.compute_single_features(poseviewers,native_poses=native_loc)
+        features.compute_single_features(poseviewers,native_poses=native_loc)
 
-    features.compute_pair_features(poseviewers,
-                                   mcss=not no_mcss, shape=use_shape, processes=processes)
+        features.compute_pair_features(poseviewers,
+                                       mcss=not no_mcss, shape=use_shape, processes=processes)
 
     return features
 
@@ -115,7 +118,8 @@ def pose_prediction(prot_features, out, stats_root, alpha=-0.6,
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--feat_root', required=True, help='directory to place features in')
-    parser.add_argument('--helper_ligands',nargs='*', required=True, help='helper ligand docked poses')
+    parser.add_argument('--helper_ligands',nargs='*', required=True, help='helper ligand docked poses (these will be filtered using the benchmark csvs, so only a subset is used)')
+    parser.add_argument('--extra_helper_ligands',nargs='*', default=[], help='extra helper ligand docked poses (these are not filtered and are always used)')
     parser.add_argument('--query_ligand', required=True,help='query ligand docked poses')
     parser.add_argument('--protein_name', required=True, help='name of protein class')
     parser.add_argument('--stats_root',required=True,help='Directory that contains helper lists and protein statistics are in `<stats_root>/protein_statistics`')
@@ -125,6 +129,8 @@ if __name__ == "__main__":
     parser.add_argument('--interactions',default='mcss,hbond,saltbridge,contact',help='interactions to use for featurization and pose prediction')
     parser.add_argument('--processes',type=int,default=1,help='# of processes to use')
     parser.add_argument('--pose_csv',help='name of pose_csv to use, if not set then `<protein_name>_<query_ligand>_<selection_criterion>.csv`')
+    parser.add_argument('--check_center_ligs',action='store_true',help='quazi-GLIDE inner box for docked poses')
+    parser.add_argument('--skip_featurization',action='store_true',help='Do not run the featurization of the ligand molecules (assumes you already have the featurization)')
     parser.add_argument('--alpha',help='alpha for the combind objective')
 
     args = parser.parse_args()
@@ -133,7 +139,8 @@ if __name__ == "__main__":
     if 'mcss' in interactions:
         no_mcss = False
     prot_features = run_featurization(args.feat_root,args.helper_ligands,args.query_ligand,args.protein_name,
-            args.stats_root,native_loc=args.native, selection_criterion=args.selection_criterion,processes=args.processes)
+            args.stats_root,native_loc=args.native, selection_criterion=args.selection_criterion,processes=args.processes,
+            check_center_ligs=args.check_center_ligs, skip_featurization=args.skip_featurization, extra_helper_ligands=args.extra_helper_ligands)
     if args.pose_csv is None:
         args.pose_csv = f"{args.protein_name}_{args.query_ligand.split('/')[-1].split('-')[0].split('_')[0]}_{args.selection_criterion}.csv"
     if args.merged_stats_root is None:

--- a/open_combind/utils.py
+++ b/open_combind/utils.py
@@ -43,11 +43,11 @@ def basename(path):
     x = os.path.splitext(x)[0]
     return x
 
-def mp(function, unfinished, processes):
+def mp(function, unfinished, processes, maxtasksperchild=None):
     if processes == -1:  # Will use all available cpus if processes is -1
         processes = None
     if unfinished:
-        with Pool(processes=processes) as pool:
+        with Pool(processes=processes, maxtasksperchild=maxtasksperchild) as pool:
             x = pool.starmap(function, unfinished)
         return x
 


### PR DESCRIPTION
## Description
Fixes the memory/runtime issue with MCSS calculation by setting a timeout of 7 minutes for the calculation of MCSS. Further addresses more memory problems that occur with multiple MCSS calculations happening at once with multiprocessing by limiting the number of concurrent processes. Added documentation for MCSS functions and removed unused functions.

## Todos
  - [x] Fixes Memory/Runtime issues with MCSS RMSD calculations
  - [x] Multiprocessing for MCSS
  - [x] Documentation for MCSS functions

## Status
- [x] Ready to go