### PR TITLE
Update CI.yaml

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -45,12 +45,12 @@ jobs:
 
     - name: Update env with python version
       shell: bash
-      run: sed -i 's,python_version,'"${{ matrix.python-version}}"',' devtools/conda-envs/test_env.yaml
+      run: sed -i 's,python_version,'"${{ matrix.config.python-version}}"',' devtools/conda-envs/test_env.yaml
 
     - name: Install OpenMM 
       uses: conda-incubator/setup-miniconda@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.config.python-version }}
         activate-environment: opencombind-dev
         environment-file: devtools/conda-envs/test_env.yaml
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -28,7 +28,7 @@ jobs:
         - {
                 os: ubuntu-latest,
                 # os: [macOS-latest, ubuntu-latest, windows-latest]
-                python-version: 3.10,
+                python-version: '3.10',
                 cc: "gcc", cxx: "g++",
         # python-version: [3.7, 3.8, 3.9]
              }
@@ -42,10 +42,6 @@ jobs:
         uname -a
         df -h
         ulimit -a
-
-    - name: Update env with python version
-      shell: bash
-      run: sed -i 's,python_version,'"${{ matrix.config.python-version}}"',' devtools/conda-envs/test_env.yaml
 
     - name: Install OpenMM 
       uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Update env with python version
       shell: bash
-      run: sed -i 's,python_version,'"${{ matrix.python-version}}"',' devtools/conda-envs/test_env.yml
+      run: sed -i 's,python_version,'"${{ matrix.python-version}}"',' open_combind/devtools/conda-envs/test_env.yml
 
     - name: Install OpenMM 
       uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -28,7 +28,7 @@ jobs:
         - {
                 os: ubuntu-latest,
                 # os: [macOS-latest, ubuntu-latest, windows-latest]
-                python-version: 3.8,
+                python-version: 3.10,
                 cc: "gcc", cxx: "g++",
         # python-version: [3.7, 3.8, 3.9]
              }
@@ -44,7 +44,7 @@ jobs:
         ulimit -a
 
     - name: Install OpenMM 
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
         activate-environment: opencombind-dev

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -43,6 +43,10 @@ jobs:
         df -h
         ulimit -a
 
+    - name: Update env with python version
+      shell: bash
+      run: sed -i 's,python_version,'"${{ matrix.python-version}}"',' devtools/conda-envs/test_env.yml
+
     - name: Install OpenMM 
       uses: conda-incubator/setup-miniconda@v3
       with:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Update env with python version
       shell: bash
-      run: sed -i 's,python_version,'"${{ matrix.python-version}}"',' open_combind/devtools/conda-envs/test_env.yml
+      run: sed -i 's,python_version,'"${{ matrix.python-version}}"',' devtools/conda-envs/test_env.yaml
 
     - name: Install OpenMM 
       uses: conda-incubator/setup-miniconda@v3

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
     # Base depends
-  - python==3.10
+  - python==python_version
   - openmm
   - numpy
   - pip

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -4,6 +4,7 @@ channels:
   - conda-forge
 dependencies:
     # Base depends
+  - python==3.10
   - openmm
   - numpy
   - pip

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -4,7 +4,6 @@ channels:
   - conda-forge
 dependencies:
     # Base depends
-  - python==python_version
   - openmm
   - numpy
   - pip


### PR DESCRIPTION
Up to date python and miniconda

## Description
Moves from CI with python 3.8 -> 3.10 and moves to conda-incubator/setup-miniconda@v3