### PR TITLE
max_posterior fix for single ligand

### DIFF
--- a/open_combind/features/ifp.py
+++ b/open_combind/features/ifp.py
@@ -438,7 +438,7 @@ class Molecule:
                         ('c1nn[nH1]n1', 0, [1, 3]),
                         ('C(=O)N[OH1,O-,OX1]', 0, [1, 2]),
                         ('CO(=N[OH1,O-])', 0, [1, 2]),
-                        ('[$(N-[SX4](=O)(=O)[CX4](F)(F)F)]', 0, [1, 2])]
+                        ('[$(N-[SX4](=O)(=O)[CX4](F)(F)F)]', 0, [0])]
 
         smartss = [(MolFromSmarts(ss), k, v, +1) for ss, k, v in pos_smartss] + [(MolFromSmarts(ss), k, v, -1) for ss, k, v in neg_smartss]
         idx_to_atom = {atom.GetIdx(): atom for atom in self.mol.GetAtoms()}

--- a/open_combind/score/pose_prediction.py
+++ b/open_combind/score/pose_prediction.py
@@ -133,7 +133,7 @@ class PosePrediction:
             {ligand_name: pose_number, }, where pose_number is the pose number selected by the objective
         """
         if len(self.ligands) == 1:
-            return {self.ligands[0]: 0}
+            return -float('inf'),{self.ligands[0]: 0}
 
         best_score, best_poses = -float('inf'), None
         for i in range(restart):


### PR DESCRIPTION
## Description
Max posterior incorrectly outputs only the pose number when there is a single ligand, also should output a pose score.

## Status
- [x] Ready to go